### PR TITLE
Update zkVerify testnet info

### DIFF
--- a/packages/chain-list/src/data/AssetLogoMap.json
+++ b/packages/chain-list/src/data/AssetLogoMap.json
@@ -747,7 +747,7 @@
   "mantle-erc20-meth-0xcda86a272531e8640cd7f1a92c01839911b90bb0": "https://dev.sw-chain-list-assets.pages.dev/assets/chain-assets/mantle-erc20-meth-0xcda86a272531e8640cd7f1a92c01839911b90bb0.png",
   "polygonzkevm-erc20-matic-0xa2036f0538221a77a3937f1379699f44945018d0": "https://dev.sw-chain-list-assets.pages.dev/assets/chain-assets/polygonzkevm-erc20-matic-0xa2036f0538221a77a3937f1379699f44945018d0.png",
   "ethereum-erc20-pol-0x455e53cbb86018ac2b8092fdcd39d8444affc3f6": "https://dev.sw-chain-list-assets.pages.dev/assets/chain-assets/ethereum-erc20-pol-0x455e53cbb86018ac2b8092fdcd39d8444affc3f6.png",
-  "zkverify_testnet-native-acme": "https://dev.sw-chain-list-assets.pages.dev/assets/chain-assets/zkverify_testnet-native-acme.png",
+  "zkverify_testnet-native-tvfy": "https://dev.sw-chain-list-assets.pages.dev/assets/chain-assets/zkverify_testnet-native-acme.png",
   "rari-native-eth": "https://dev.sw-chain-list-assets.pages.dev/assets/chain-assets/rari-native-eth.png",
   "scroll-native-eth": "https://dev.sw-chain-list-assets.pages.dev/assets/chain-assets/scroll-native-eth.png",
   "sepolia_ethereum-erc20-avail-0xb1c3cb9b5e598d4e95a85870e7812b99f350982d": "https://dev.sw-chain-list-assets.pages.dev/assets/chain-assets/sepolia_ethereum-erc20-avail-0xb1c3cb9b5e598d4e95a85870e7812b99f350982d.png",

--- a/packages/chain-list/src/data/ChainAsset.json
+++ b/packages/chain-list/src/data/ChainAsset.json
@@ -12609,14 +12609,14 @@
     "hasValue": true,
     "icon": "https://dev.sw-chain-list-assets.pages.dev/assets/chain-assets/ethereum-erc20-pol-0x455e53cbb86018ac2b8092fdcd39d8444affc3f6.png"
   },
-  "zkverify_testnet-NATIVE-ACME": {
+  "zkverify_testnet-NATIVE-TVFY": {
     "originChain": "zkverify_testnet",
-    "slug": "zkverify_testnet-NATIVE-ACME",
-    "name": "zkVerify Testnet",
-    "symbol": "ACME",
+    "slug": "zkverify_testnet-NATIVE-TVFY",
+    "name": "zkVerify Volta",
+    "symbol": "TVFY",
     "decimals": 18,
     "priceId": null,
-    "minAmount": "10000000000000",
+    "minAmount": "10000000000000000",
     "assetType": "NATIVE",
     "metadata": null,
     "multiChainAsset": null,

--- a/packages/chain-list/src/data/ChainInfo.json
+++ b/packages/chain-list/src/data/ChainInfo.json
@@ -10425,24 +10425,24 @@
   },
   "zkverify_testnet": {
     "slug": "zkverify_testnet",
-    "name": "zkVerify Testnet",
+    "name": "zkVerify Volta",
     "isTestnet": true,
     "chainStatus": "ACTIVE",
     "icon": "https://dev.sw-chain-list-assets.pages.dev/assets/chains/zkverify_testnet.png",
     "providers": {
-      "zkVerify": "wss://testnet-rpc.zkverify.io"
+      "zkVerify": "wss://volta-rpc.zkverify.io"
     },
     "evmInfo": null,
     "substrateInfo": {
       "relaySlug": null,
       "paraId": null,
-      "genesisHash": "0xc00425dcaa0a1bc5bf1163a2d69d7abb2cc6180de78b4e10297b31a4d9cc928a",
+      "genesisHash": "0xff7fe5a610f15fe7a0c52f94f86313fb7db7d3786e7f8acf2b66c11d5be7c242",
       "addressPrefix": 251,
       "chainType": "RELAYCHAIN",
       "crowdloanUrl": null,
-      "blockExplorer": "https://testnet-explorer.zkverify.io/",
-      "existentialDeposit": "10000000000000",
-      "symbol": "ACME",
+      "blockExplorer": "https://zkverify-testnet.subscan.io/",
+      "existentialDeposit": "10000000000000000",
+      "symbol": "tVFY",
       "decimals": 18,
       "hasNativeNft": null,
       "supportStaking": null,


### PR DESCRIPTION
We've made some changes to the already integrated zkVerify Testnet, namely:
- Official testnet name "Volta"
- Token ticker "ACME" -> "tVFY"
- Changed RPC endpoints & explorer link
Thanks in advance !
