### PR TITLE
Update xDAI to XDAI for Gnosis chain and asset

### DIFF
--- a/packages/chain-list/src/data/ChainAsset.json
+++ b/packages/chain-list/src/data/ChainAsset.json
@@ -13735,7 +13735,7 @@
     "hasValue": false,
     "icon": "/assets/chain-assets/autonomys_taurus-native-tai3.png"
   },
-  "gnosis-NATIVE-xDAI": {
+  "gnosis-NATIVE-XDAI": {
     "originChain": "gnosis",
     "slug": "gnosis-NATIVE-xDAI",
     "name": "xDAI",

--- a/packages/chain-list/src/data/ChainInfo.json
+++ b/packages/chain-list/src/data/ChainInfo.json
@@ -10851,7 +10851,7 @@
       "evmChainId": 100,
       "blockExplorer": "https://gnosisscan.io/",
       "existentialDeposit": "0",
-      "symbol": "xDAI",
+      "symbol": "XDAI",
       "decimals": 18,
       "supportSmartContract": [
         "ERC721",


### PR DESCRIPTION
[EVM] [Gnosis Chain] [XDAI] Update xDAI symbol to XDAI (uppercase correction)
Description
Updates the Gnosis Chain native asset symbol from xDAI to XDAI to match official branding. This is a correction to existing data, not a new integration.
Changes Made
ChainInfo.json (line 10854): Updated evmInfo.symbol from "xDAI" to "XDAI"
ChainAsset.json (lines 13738-13742): Updated asset entry:
Key: "gnosis-NATIVE-xDAI" → "gnosis-NATIVE-XDAI"
Slug: "gnosis-NATIVE-xDAI" → "gnosis-NATIVE-XDAI"
Name: "xDAI" → "XDAI"
Symbol: "xDAI" → "XDAI"
Related Issues
N/A - This is a data correction to align with official branding
Notes
The priceId field remains "xdai" (lowercase) as it's an API identifier that requires lowercase format
File paths remain lowercase (gnosis-native-xdai.png) as per file naming conventions
This change affects only the display symbol and internal references, not the underlying asset functionality
Documents and References
Official Gnosis Chain documentation: https://docs.gnosis.io/
Gnosis Chain website: https://www.gnosis.io/
This aligns with standard token symbol conventions (uppercase for display)
Files Changed
packages/chain-list/src/data/ChainInfo.json
packages/chain-list/src/data/ChainAsset.json
