### PR TITLE
Remove XCM support for MANTA tokens on Substrate networks (#604)

### DIFF
--- a/packages/chain-list/src/data/AssetRef.json
+++ b/packages/chain-list/src/data/AssetRef.json
@@ -545,20 +545,6 @@
     "destChain": "centrifuge",
     "path": "XCM"
   },
-  "manta_network-NATIVE-MANTA___moonbeam-LOCAL-xcMANTA": {
-    "srcAsset": "manta_network-NATIVE-MANTA",
-    "destAsset": "moonbeam-LOCAL-xcMANTA",
-    "srcChain": "manta_network",
-    "destChain": "moonbeam",
-    "path": "XCM"
-  },
-  "manta_network-NATIVE-MANTA___bifrost_dot-LOCAL-MANTA": {
-    "srcAsset": "manta_network-NATIVE-MANTA",
-    "destAsset": "bifrost_dot-LOCAL-MANTA",
-    "srcChain": "manta_network",
-    "destChain": "bifrost_dot",
-    "path": "XCM"
-  },
   "manta_network-LOCAL-DOT___polkadot-NATIVE-DOT": {
     "srcAsset": "manta_network-LOCAL-DOT",
     "destAsset": "polkadot-NATIVE-DOT",
@@ -571,20 +557,6 @@
     "destAsset": "moonbeam-LOCAL-xcDOT",
     "srcChain": "manta_network",
     "destChain": "moonbeam",
-    "path": "XCM"
-  },
-  "moonbeam-LOCAL-xcMANTA___manta_network-NATIVE-MANTA": {
-    "srcAsset": "moonbeam-LOCAL-xcMANTA",
-    "destAsset": "manta_network-NATIVE-MANTA",
-    "srcChain": "moonbeam",
-    "destChain": "manta_network",
-    "path": "XCM"
-  },
-  "bifrost_dot-LOCAL-MANTA___manta_network-NATIVE-MANTA": {
-    "srcAsset": "bifrost_dot-LOCAL-MANTA",
-    "destAsset": "manta_network-NATIVE-MANTA",
-    "srcChain": "bifrost_dot",
-    "destChain": "manta_network",
     "path": "XCM"
   },
   "rococo_assethub-NATIVE-ROC___rococo-NATIVE-ROC": {


### PR DESCRIPTION
- Remove MANTA: Manta Atlantic <> Bifrost XCM channel
- Remove MANTA: Manta Atlantic <> Moonbeam (xcMANTA) XCM channel



**Related issues**
Fixes: #604 
https://github.com/Koniverse/SubWallet-ChainList/issues/604
