### PR TITLE
[Ethereum] [Mythos] [MYTH] Enable MYTH bridging from Ethereum to Mythos via Snowbridge (#411)

### DIFF
--- a/packages/chain-list/src/data/AssetRef.json
+++ b/packages/chain-list/src/data/AssetRef.json
@@ -706,6 +706,13 @@
     "destChain": "mythos",
     "path": "XCM"
   },
+  "ethereum-ERC20-MYTH-0xBA41Ddf06B7fFD89D1267b5A93BFeF2424eb2003___mythos-NATIVE-MYTH": {
+    "srcAsset": "ethereum-ERC20-MYTH-0xBA41Ddf06B7fFD89D1267b5A93BFeF2424eb2003",
+    "destAsset": "mythos-NATIVE-MYTH",
+    "srcChain": "ethereum",
+    "destChain": "mythos",
+    "path": "XCM"
+  },
   "statemint-LOCAL-WBTC___ethereum-ERC20-WBTC-0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599": {
     "srcAsset": "statemint-LOCAL-WBTC",
     "destAsset": "ethereum-ERC20-WBTC-0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",


### PR DESCRIPTION
## Related issues
Fixes #411

## Summary
This PR enables in-app bridging for MYTH token from Ethereum to Mythos via Snowbridge by adding the necessary asset reference configuration.

## Changes Made
- Added new asset reference entry in `AssetRef.json` to enable MYTH bridging from Ethereum to Mythos
- Source: `ethereum-ERC20-MYTH-0xBA41Ddf06B7fFD89D1267b5A93BFeF2424eb2003`
- Destination: `mythos-NATIVE-MYTH`
- Path: `XCM` (Snowbridge routing mechanism)

## Technical Details
- **Source Asset**: Ethereum ERC20 MYTH token (contract: `0xBA41Ddf06B7fFD89D1267b5A93BFeF2424eb2003`)
- **Destination Asset**: Mythos native MYTH token
- **Bridging Path**: XCM via Snowbridge
- **Entry Location**: Added after line 708 in `AssetRef.json`, keeping MYTH-related entries grouped together

## Verification
-  JSON syntax validated
-  Entry format matches existing asset references
-  No duplicate entries
-  Proper comma placement and JSON structure

## Testing
The asset reference has been added and follows the same format as other bridging entries in the file. This enables the in-app bridging feature for MYTH tokens from Ethereum to Mythos.